### PR TITLE
[fixed] check if the modal content is available when async update...

### DIFF
--- a/src/components/ModalPortal.js
+++ b/src/components/ModalPortal.js
@@ -130,7 +130,8 @@ export default class ModalPortal extends Component {
   }
 
   // Don't steal focus from inner elements
-  focusContent = () => (!this.contentHasFocus()) && this.content.focus();
+  focusContent = () => 
+    (this.content && !this.contentHasFocus()) && this.content.focus();
 
   closeWithTimeout = () => {
     const closesAt = Date.now() + this.props.closeTimeoutMS;


### PR DESCRIPTION
It seems that the using redux, we can get a async update in which can fail
when trying to focus the content of the modal.

This should be a temporary fix since the issue is hard to reproduce,
but safe for other applications.

Fixes #315.

Acceptance Checklist:
- [x] All commits have been squashed to one.
- [x] The commit message follows the guidelines in `CONTRIBUTING.md`.
- [x] Documentation (README.md) and examples have been updated as needed.
- [x] If this is a code change, a spec testing the functionality has been added.
- [x] If the commit message has [changed] or [removed], there is an upgrade path above.
